### PR TITLE
Permissions not checked properly for users other than UID 1.

### DIFF
--- a/bueditor.inc
+++ b/bueditor.inc
@@ -196,12 +196,12 @@ function bueditor_user_eids($user) {
   $roles = $config->get('bueditor_roles');
   // Anonymous user
   if (empty($user->uid)) {
-    $rid = BACKDROP_ANONYMOUS_RID;
+    $rid = BACKDROP_ANONYMOUS_ROLE;
     return isset($roles[$rid]) ? array($roles[$rid]['editor'], $roles[$rid]['alt']) : array('', '');
   }
   // Other users
   foreach ($roles as $rid => $role) {
-    if (isset($user->roles[$rid]) && ($role['editor'] || $role['alt'])) {
+    if (in_array($rid, $user->roles) && ($role['editor'] || $role['alt'])) {
       return array($role['editor'], $role['alt']);
     }
   }


### PR DESCRIPTION
Looks like the roles aren't checked correctly for users other than UID 1.
- `BACKDROP_ANONYMOUS_RID` isn't defined, it's `BACKDROP_ANONYMOUS_ROLE`
- The `$user->roles` array is an unindexed list of role names, so we need to use `in_array()` instead of `isset()`

Other than that, looks like this module is working! Excellent. :smile:
